### PR TITLE
feat(Pin numpy version) New numpy version breaks a test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 *.toc
 *.aux
 *.out
+.python-version
+.vscode
+.pytest_cache
 book_files/
 dist/
 *egg-info*
 _build/
+env
 _static
 _templatesq
 quadrature.py

--- a/filterpy/kalman/tests/test_ukf.py
+++ b/filterpy/kalman/tests/test_ukf.py
@@ -52,10 +52,11 @@ def test_sigma_plot():
     assert max(Xi1[:,1]) > max(Xi0[:,1])
 
 def test_julier_weights():
-    for n in range(1,15):
-        for k in np.linspace(0,5,0.1):
-            Wm = UKF.weights(n, k)
-
+    for n in range(1, 15):
+        for k in np.linspace(0, 5, 51):
+            jp = JulierSigmaPoints(n, k)
+            Wm = jp.weights()[0]
+            Wc = jp.weights()[1]
             assert abs(sum(Wm) - 1) < 1.e-12
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,54 +5,19 @@ import filterpy
 
 here = path.abspath(path.dirname(__file__))
 
-# Get the long description from the relevant file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
     name='censio-filterpy',
-
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # http://packaging.python.org/en/latest/tutorial.html#version
-    version="0.0.UNKNOWN",
-
+    version="1.0.UNKNOWN",
     description='Kalman filtering and optimal estimation library',
     long_description=long_description,
-
-    # The project's main homepage.
     url='https://github.com/rlabbe/filterpy',
-
-    # Author details
     author='Roger Labbe',
     author_email='rlabbejr@gmail.com',
-
-    # Choose your license
     license='MIT',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        'Development Status :: 4 - Beta',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Topic :: Scientific/Engineering :: Physics',
-        'Topic :: Utilities',
-
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: MIT License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
@@ -60,40 +25,23 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
-
-    # What does your project relate to?
-    keywords='Kalman filters filtering optimal estimation tracking',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib']),
-
-    # List run-time dependencies here.  These will be installed by pip when your
-    # project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['numpy', 'scipy'],
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
+    install_requires=[
+        # Feel free to raise these version numbers any time,
+        # I just wanted to pin them in order to not break anything upstream
+        # when a new numpy/scipy version is released
+        'numpy<=1.18.1',
+        'scipy<=1.4.1'
+    ],
+    tests_require = [
+        'pytest'
+    ]
     package_data={
         'filterpy': ['README.rst', 'changelog.txt', 'LICENSE.txt'],
     },
-
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages.
-    # see http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    #data_files=[('my_data', ['data/data_file'])],
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    #entry_points={
-    #    'console_scripts': [
-    #        'sample=sample:main',
-    #    ],
-    #},
 )


### PR DESCRIPTION
As part of Python 2 to 3 migration project.

- Created virtualenvs for python 2.7.4, 3.7.16, 3.8.1: all tests succeeded for all versions.
- Numpy 1.18.0 breaks one of the tests: https://github.com/Censio/filterpy/blob/master/filterpy/kalman/tests/test_ukf.py#L56

The third parameter is a float but it should be an int. If I make it an int, the test fails, so I didn't know what to do